### PR TITLE
added `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    groups:
+      types:
+        patterns:
+          - '@types/*'
+      lint-formatter:
+        patterns:
+          - '*eslint*'
+          - '*prettier*'
+      patches:
+        update-types:
+          - 'patch'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    groups:
+      actions-deps:
+        patterns:
+          - '*'


### PR DESCRIPTION
added dependabot config for `npm` and `github-actions`

according to [this page](https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory), we needn't setting absolute path strictly