### PR TITLE
textboxコンポーネントがattributeを継承するように

### DIFF
--- a/src/components/Controls/Textbox/EmailTextbox.vue
+++ b/src/components/Controls/Textbox/EmailTextbox.vue
@@ -4,6 +4,9 @@ import TextboxLabel from '@/components/Controls/Textbox/TextboxLabel.vue'
 import { computed } from 'vue'
 import isEmail from 'validator/lib/isEmail'
 
+defineOptions({
+  inheritAttrs: false
+})
 const { errorMessage = '', label = '' } = defineProps<{
   disabled?: boolean
   errorMessage?: string
@@ -22,6 +25,7 @@ const isError = computed(() => errorMessage != '' || isEmailError.value)
     <TextboxLabel v-if="label != ''" :is-required="isRequired" :label="label" />
     <input
       v-model="value"
+      v-bind="$attrs"
       :autocomplete="autocomplete"
       :class="[
         {

--- a/src/components/Controls/Textbox/PasswordTextbox.vue
+++ b/src/components/Controls/Textbox/PasswordTextbox.vue
@@ -3,6 +3,9 @@ import MaterialIcon from '@/components/MaterialIcon.vue'
 import TextboxLabel from '@/components/Controls/Textbox/TextboxLabel.vue'
 import { computed, ref } from 'vue'
 
+defineOptions({
+  inheritAttrs: false
+})
 const { errorMessage = '', label = '' } = defineProps<{
   disabled?: boolean
   errorMessage?: string
@@ -22,6 +25,7 @@ const passwordShown = ref<boolean>(false)
     <span class="relative">
       <input
         v-model="value"
+        v-bind="$attrs"
         :class="[
           {
             'border-border-secondary outline-text-primary focus:border-text-primary': !isError

--- a/src/components/Controls/Textbox/PlainTextbox.vue
+++ b/src/components/Controls/Textbox/PlainTextbox.vue
@@ -3,13 +3,17 @@ import MaterialIcon from '@/components/MaterialIcon.vue'
 import TextboxLabel from '@/components/Controls/Textbox/TextboxLabel.vue'
 import { computed } from 'vue'
 
-const { errorMessage = '', label = '' } = defineProps<{
-  disabled?: boolean
+defineOptions({
+  inheritAttrs: false
+})
+const {
+  errorMessage = '',
+  label = '',
+  isRequired
+} = defineProps<{
   errorMessage?: string
-  isRequired?: boolean
   label?: string
-  placeholder?: string
-  autocomplete?: string
+  isRequired?: boolean
 }>()
 const value = defineModel<string>()
 const isError = computed(() => errorMessage != '')
@@ -17,10 +21,10 @@ const isError = computed(() => errorMessage != '')
 
 <template>
   <div class="flex flex-col gap-2">
-    <TextboxLabel v-if="label != ''" :is-required="isRequired" :label="label" />
+    <TextboxLabel v-if="label != ''" :is-required="isRequired" :label="label" :for="$attrs.id" />
     <input
       v-model="value"
-      :autocomplete="autocomplete"
+      v-bind="$attrs"
       :class="[
         {
           'border-border-secondary outline-text-primary focus:border-text-primary': !isError
@@ -28,9 +32,6 @@ const isError = computed(() => errorMessage != '')
         { 'border-status-error outline outline-1 outline-status-error': isError },
         'fontstyle-ui-body w-full rounded border bg-background-primary py-1 pl-4 text-text-primary placeholder:text-text-tertiary focus:outline focus:outline-1 disabled:bg-background-secondary'
       ]"
-      :disabled="disabled"
-      :placeholder="placeholder"
-      type="text"
     />
     <div v-if="isError" class="flex items-start gap-2 pl-1 text-status-error">
       <MaterialIcon icon="error" size="1.25rem" />

--- a/src/views/SignupView.vue
+++ b/src/views/SignupView.vue
@@ -44,8 +44,10 @@ async function onEmailSignup() {
           <OAuthButton app="traQ" mode="signup" class="w-full" />
         </div>
         <div class="flex-1 space-y-3 p-2.5 pl-4">
-          <div class="fontstyle-ui-body-strong text-left">メールアドレスで新規登録</div>
-          <EmailTextbox v-model="emailAddress" placeholder="メールアドレス" />
+          <label class="fontstyle-ui-body-strong text-left" for="email"
+            >メールアドレスで新規登録</label
+          >
+          <EmailTextbox id="email" v-model="emailAddress" placeholder="メールアドレス" />
           <PrimaryButton text="次へ" class="w-full" @click="onEmailSignup" />
           <div class="fontstyle-ui-caption-link text-left">
             <a href="login">すでにアカウントをお持ちの場合</a>


### PR DESCRIPTION
テキストコンポーネントを使用する際に，`id`属性などコンポーネントに割り当てられた属性をinputに継承するようにしました。また，これを利用している既存のコードのうち，適切にlabelと対応づけられていなかったものについて修正しました。

close #75