### PR TITLE
Textboxのデザイン修正

### DIFF
--- a/src/components/Controls/Textbox/PlainTextbox.vue
+++ b/src/components/Controls/Textbox/PlainTextbox.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import MaterialIcon, { type Icon } from '@/components/MaterialIcon.vue'
-import { computed, onMounted, ref, useTemplateRef } from 'vue'
+import { computed, ref, useTemplateRef } from 'vue'
 
 defineOptions({
   inheritAttrs: false
@@ -46,52 +46,54 @@ const onClickInnerBorder = (e: MouseEvent) => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-1">
-    <span v-if="label != ''" class="flex items-center gap-2">
-      <label class="fontstyle-ui-control text-text-primary" :for="id">{{ label }}</label>
-      <span v-if="required" class="fontstyle-ui-caption-strong text-status-error">必須</span>
-    </span>
-    <span
-      class="flex rounded border bg-background-primary px-2 py-1"
-      :class="[
-        { 'outline outline-1': isFocused },
-        { 'border-border-secondary outline-text-primary': !displaysError },
-        { 'border-status-error outline outline-1 outline-status-error': displaysError },
-        { 'border-text-primary': isFocused && !displaysError },
-        { 'bg-background-secondary': disabled }
-      ]"
-      @mousedown="onClickInnerBorder"
-    >
-      <MaterialIcon v-if="displaysLeftIcon" :icon="leftIcon!" size="1.25rem" />
-      <input
-        v-bind="$attrs"
-        :id="id"
-        ref="input"
-        v-model="value"
-        :disabled="disabled"
-        class="fontstyle-ui-body h-5 w-full min-w-0 bg-transparent px-2 text-text-primary outline-none placeholder:text-text-tertiary"
-        @focusin="onFocusin"
-        @blur="onBlur"
-      />
-      <span class="inline-flex items-center gap-2">
-        <span v-if="displaysLength" class="fontstyle-ui-caption text-text-secondary">{{
-          value?.length ?? 0
-        }}</span>
-        <MaterialIcon
-          v-if="displaysRightIcon"
-          :icon="rightIcon!"
-          size="1.25rem"
-          @click="emit('clickRight')"
-        />
+  <div>
+    <div class="flex flex-col gap-1">
+      <span v-if="label != ''" class="flex items-center gap-2">
+        <label class="fontstyle-ui-control text-text-primary" :for="id">{{ label }}</label>
+        <span v-if="required" class="fontstyle-ui-caption-strong text-status-error">必須</span>
       </span>
-    </span>
-    <span v-if="displaysSupportingText" class="fontstyle-ui-caption text-text-secondary">{{
-      supportingText
-    }}</span>
-  </div>
-  <div v-if="displaysError" class="mt-2 flex items-start gap-2 text-status-error">
-    <MaterialIcon icon="error" size="1.25rem" is-filled />
-    <span class="fontstyle-ui-control min-w-0 break-words">{{ errorMessage }}</span>
+      <span
+        class="box-border flex h-9 items-center rounded border  bg-background-primary px-2"
+        :class="[
+          { 'outline outline-1': isFocused },
+          { 'border-border-secondary outline-text-primary': !displaysError },
+          { 'border-status-error outline outline-1 outline-status-error': displaysError },
+          { 'border-text-primary': isFocused && !displaysError },
+          { 'bg-background-secondary': disabled }
+        ]"
+        @mousedown="onClickInnerBorder"
+      >
+        <MaterialIcon v-if="displaysLeftIcon" :icon="leftIcon!" size="1.25rem" class="text-text-secondary" />
+        <input
+          v-bind="$attrs"
+          :id="id"
+          ref="input"
+          v-model="value"
+          :disabled="disabled"
+          class="fontstyle-ui-body h-6 w-full min-w-0 bg-transparent px-2 text-text-primary outline-none placeholder:text-text-tertiary"
+          @focusin="onFocusin"
+          @blur="onBlur"
+        />
+        <span class="inline-flex items-center gap-2">
+          <span v-if="displaysLength" class="fontstyle-ui-caption text-text-secondary">{{
+            value?.length ?? 0
+          }}</span>
+          <MaterialIcon
+            v-if="displaysRightIcon"
+            :icon="rightIcon!"
+            size="1.25rem"
+            @click="emit('clickRight')"
+          />
+        </span>
+      </span>
+      <span v-if="displaysSupportingText" class="fontstyle-ui-caption text-text-secondary">{{
+        supportingText
+      }}</span>
+    </div>
+    <div v-if="displaysError" class="mt-2 flex items-start gap-2 text-status-error">
+      <MaterialIcon icon="error" size="1.25rem" is-filled />
+      <span class="fontstyle-ui-control min-w-0 break-words">{{ errorMessage }}</span>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
fix #118, fix #120
要素の高さ・アイコンの色をFigmaのものに揃えました。
外部からスタイルを適用しやすいよう、divで囲みました。

(変更前)
<img width="788" alt="image" src="https://github.com/user-attachments/assets/1c8cb415-ea64-4069-8f6b-5fd8bf16bc69" />
(変更後)
<img width="788" alt="image" src="https://github.com/user-attachments/assets/1b75a02c-232d-4f56-aedb-50d3aa8ecde7" />
