### PR TITLE
問題一覧テーブルとサイドメニューからのアクセス

### DIFF
--- a/src/components/Navigations/SideMenu/SideMenuBase.vue
+++ b/src/components/Navigations/SideMenu/SideMenuBase.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { useRouter } from 'vue-router'
 import MenuButton from '@/components/Navigations/MenuButton.vue'
 import type { Icon } from '@/components/MaterialIcon.vue'
-import router from '@/router'
+
+const router = useRouter()
 
 export type SideMenuProps = {
   icon: Icon

--- a/src/components/Navigations/SideMenu/SideMenuBase.vue
+++ b/src/components/Navigations/SideMenu/SideMenuBase.vue
@@ -1,19 +1,19 @@
 <script setup lang="ts">
 import MenuButton from '@/components/Navigations/MenuButton.vue'
 import type { Icon } from '@/components/MaterialIcon.vue'
-import { ref } from 'vue'
+import router from '@/router'
 
 export type SideMenuProps = {
   icon: Icon
   text: string
-  onClick: () => void
+  href?: string
+  onClick?: () => void
 }
 const { bottomContents = [] } = defineProps<{
   mainContents: SideMenuProps[]
   bottomContents?: SideMenuProps[]
 }>()
-
-const currentTab = ref(0)
+const currentTab = defineModel<number>({ default: 0 })
 </script>
 
 <template>
@@ -23,34 +23,52 @@ const currentTab = ref(0)
     </div>
     <div class="flex grow flex-col">
       <ul class="flex flex-col gap-1">
-        <li v-for="content in mainContents" :key="content.text">
-          <MenuButton
-            :icon="content.icon"
-            :text="content.text"
-            :selected="mainContents.indexOf(content) === currentTab"
-            @click="
-              () => {
-                currentTab = mainContents.indexOf(content)
-                content.onClick()
-              }
-            "
-          />
-        </li>
+        <component
+          :is="content.href == null ? 'span' : 'a'"
+          v-for="content in mainContents"
+          :key="content.text"
+          :href="content.href"
+          @click.prevent
+        >
+          <li>
+            <MenuButton
+              :icon="content.icon"
+              :selected="mainContents.indexOf(content) === currentTab"
+              :text="content.text"
+              @click="
+                () => {
+                  currentTab = mainContents.indexOf(content)
+                  content.onClick?.()
+                  if (content.href != null) router.push(content.href)
+                }
+              "
+            />
+          </li>
+        </component>
       </ul>
       <ul class="mt-auto flex flex-col gap-1 pb-6">
-        <li v-for="content in bottomContents" :key="content.text">
-          <MenuButton
-            :icon="content.icon"
-            :text="content.text"
-            :selected="mainContents.length + bottomContents.indexOf(content) === currentTab"
-            @click="
-              () => {
-                currentTab = mainContents.length + bottomContents.indexOf(content)
-                content.onClick()
-              }
-            "
-          />
-        </li>
+        <component
+          :is="content.href == null ? 'span' : 'a'"
+          v-for="content in bottomContents"
+          :key="content.text"
+          :href="content.href"
+          @click.prevent
+        >
+          <li>
+            <MenuButton
+              :icon="content.icon"
+              :selected="mainContents.length + bottomContents.indexOf(content) === currentTab"
+              :text="content.text"
+              @click="
+                () => {
+                  currentTab = mainContents.length + bottomContents.indexOf(content)
+                  content.onClick?.()
+                  if (content.href != null) router.push(content.href)
+                }
+              "
+            />
+          </li>
+        </component>
       </ul>
     </div>
   </nav>

--- a/src/components/Navigations/SideMenu/SideMenuUserPage.vue
+++ b/src/components/Navigations/SideMenu/SideMenuUserPage.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import SideMenuBase, {
   type SideMenuProps
 } from '@/components/Navigations/SideMenu/SideMenuBase.vue'
-import { computed } from 'vue'
 
-const { isMe = false } = defineProps<{
+const route = useRoute()
+
+const { isMe = false, username } = defineProps<{
   isMe?: boolean
   username: string
 }>()
@@ -21,16 +24,12 @@ const mainContents: SideMenuProps[] = [
   {
     text: '提出一覧',
     icon: 'format_list_bulleted',
-    onClick: () => {
-      console.log('TODO: 提出一覧')
-    }
+    href: `/users/${username}/submissions`
   },
   {
     text: '問題一覧',
     icon: 'library_books',
-    onClick: () => {
-      console.log('TODO: 問題一覧')
-    }
+    href: `/users/${username}/problems`
   }
 ]
 const bottomContents = computed((): SideMenuProps[] => {
@@ -45,10 +44,24 @@ const bottomContents = computed((): SideMenuProps[] => {
     }
   ]
 })
+
+const currentTab = ref<number>(0)
+watch(
+  () => route.path,
+  (path) => {
+    const index = mainContents.findIndex((content) => content.href === path)
+    if (index >= 0) currentTab.value = index
+  },
+  { immediate: true }
+)
 </script>
 
 <template>
-  <SideMenuBase :main-contents="mainContents" :bottom-contents="bottomContents">
+  <SideMenuBase
+    v-model="currentTab"
+    :bottom-contents="bottomContents"
+    :main-contents="mainContents"
+  >
     <div class="flex w-full flex-col items-center justify-center">
       <img src="" alt="user-icon" class="size-40 rounded-full" />
       <span class="mt-2 font-primary text-xl font-semibold text-text-primary">{{ username }}</span>

--- a/src/components/ProblemsList.vue
+++ b/src/components/ProblemsList.vue
@@ -1,0 +1,85 @@
+<script lang="ts" setup>
+import { ref, watch } from 'vue'
+import { dateToString } from '@/utils/date'
+import { ProblemsApi, type ProblemSummaries, type ProblemSummary } from '@/api/generated'
+import ListingTable, { type Column } from '@/components/ListingTable.vue'
+import PageSwitcher from '@/components/PageSwitcher.vue'
+
+const { username, rowPerPage = 20 } = defineProps<{ username: string; rowPerPage?: number }>()
+const page = defineModel<number>('page', { default: 0 })
+
+const isLoaded = ref<boolean>(false)
+const totalProblems = ref<number>(0)
+const totalPage = ref<number>(0)
+const problemIds = ref<string[]>([])
+const problems = ref<Map<string, ProblemSummary>>(new Map())
+
+/**
+ * Fetch the problems with the current state and update the state
+ */
+const loadProblems = async () => {
+  isLoaded.value = false
+  try {
+    const summaries: ProblemSummaries = await new ProblemsApi().getProblems({
+      orderBy: 'createdAtDesc',
+      username,
+      limit: rowPerPage,
+      offset: page.value * rowPerPage
+    })
+
+    problemIds.value = summaries.problems?.map(({ id }) => id) ?? []
+    problems.value = new Map(summaries.problems?.map((problem) => [problem.id, problem]))
+
+    totalProblems.value = summaries.total ?? problemIds.value.length
+    totalPage.value = Math.ceil(totalProblems.value / rowPerPage)
+    if (page.value >= totalPage.value) page.value = totalPage.value - 1
+  } catch (error) {
+    console.error('API Error:', error)
+    alert(`API Error: ${error}`)
+  } finally {
+    isLoaded.value = true
+  }
+}
+
+watch(page, () => loadProblems(), { immediate: true })
+
+const cols: (Column & { name: string })[] = [
+  { id: 'createdAt', textAlign: 'start', name: '投稿日時' },
+  { id: 'title', textAlign: 'start', name: '問題名' },
+  { id: 'difficulty', textAlign: 'end', name: '難易度' },
+  { id: 'solvedCount', textAlign: 'end', name: 'Solve 数' }
+] as const
+</script>
+
+<template>
+  <PageSwitcher v-model="page" :begin="0" :end="totalPage" />
+  <div class="my-6">
+    <!-- TODO: add sorting and filtering features -->
+    <!-- Nullish になり得ない所でも型安全性のため Non-null Assertion はしない -->
+    <ListingTable v-if="isLoaded" :cols="cols" :row-ids="problemIds">
+      <template #head="{ colId }">
+        {{ cols.find(({ id }) => id === colId)?.name }}
+      </template>
+      <template #cell="{ rowId, colId }">
+        <!-- 文字列のみとは限らずリンクやアイコンなどを含めるようにするため、関数に切り出してはいない -->
+        <template v-if="colId === 'createdAt'">
+          {{ dateToString(problems.get(rowId)?.createdAt) }}
+        </template>
+        <template v-else-if="colId === 'title'">
+          {{ problems.get(rowId)?.title }}
+        </template>
+        <template v-else-if="colId === 'difficulty'">
+          {{ problems.get(rowId)?.difficulty }}
+        </template>
+        <template v-else-if="colId === 'solvedCount'">
+          {{ problems.get(rowId)?.solvedCount }}
+        </template>
+        <template v-else>Unknown column: {{ colId }}</template>
+      </template>
+    </ListingTable>
+    <div v-else>読み込み中...</div>
+  </div>
+  <PageSwitcher v-model="page" :begin="0" :end="totalPage" />
+</template>
+
+<style scoped></style>

--- a/src/components/ProblemsList.vue
+++ b/src/components/ProblemsList.vue
@@ -52,34 +52,32 @@ const cols: (Column & { name: string })[] = [
 </script>
 
 <template>
-  <PageSwitcher v-model="page" :begin="0" :end="totalPage" />
-  <div class="my-6">
-    <!-- TODO: add sorting and filtering features -->
-    <!-- Nullish になり得ない所でも型安全性のため Non-null Assertion はしない -->
-    <ListingTable v-if="isLoaded" :cols="cols" :row-ids="problemIds">
-      <template #head="{ colId }">
-        {{ cols.find(({ id }) => id === colId)?.name }}
+  <PageSwitcher v-if="totalPage > 1" v-model="page" :begin="0" :end="totalPage" class="mb-6" />
+  <!-- TODO: add sorting and filtering features -->
+  <!-- Nullish になり得ない所でも型安全性のため Non-null Assertion はしない -->
+  <ListingTable v-if="isLoaded" :cols="cols" :row-ids="problemIds">
+    <template #head="{ colId }">
+      {{ cols.find(({ id }) => id === colId)?.name }}
+    </template>
+    <template #cell="{ rowId, colId }">
+      <!-- 文字列のみとは限らずリンクやアイコンなどを含めるようにするため、関数に切り出してはいない -->
+      <template v-if="colId === 'createdAt'">
+        {{ dateToString(problems.get(rowId)?.createdAt) }}
       </template>
-      <template #cell="{ rowId, colId }">
-        <!-- 文字列のみとは限らずリンクやアイコンなどを含めるようにするため、関数に切り出してはいない -->
-        <template v-if="colId === 'createdAt'">
-          {{ dateToString(problems.get(rowId)?.createdAt) }}
-        </template>
-        <template v-else-if="colId === 'title'">
-          {{ problems.get(rowId)?.title }}
-        </template>
-        <template v-else-if="colId === 'difficulty'">
-          {{ problems.get(rowId)?.difficulty }}
-        </template>
-        <template v-else-if="colId === 'solvedCount'">
-          {{ problems.get(rowId)?.solvedCount }}
-        </template>
-        <template v-else>Unknown column: {{ colId }}</template>
+      <template v-else-if="colId === 'title'">
+        {{ problems.get(rowId)?.title }}
       </template>
-    </ListingTable>
-    <div v-else>読み込み中...</div>
-  </div>
-  <PageSwitcher v-model="page" :begin="0" :end="totalPage" />
+      <template v-else-if="colId === 'difficulty'">
+        {{ problems.get(rowId)?.difficulty }}
+      </template>
+      <template v-else-if="colId === 'solvedCount'">
+        {{ problems.get(rowId)?.solvedCount }}
+      </template>
+      <template v-else>Unknown column: {{ colId }}</template>
+    </template>
+  </ListingTable>
+  <div v-else>読み込み中...</div>
+  <PageSwitcher v-if="totalPage > 1" v-model="page" :begin="0" :end="totalPage" class="mt-6" />
 </template>
 
 <style scoped></style>

--- a/src/components/SubmissionsList.vue
+++ b/src/components/SubmissionsList.vue
@@ -57,43 +57,41 @@ const cols: (Column & { name: string })[] = [
 </script>
 
 <template>
-  <PageSwitcher v-model="page" :begin="0" :end="totalPage" />
-  <div class="my-6">
-    <!-- TODO: add sorting and filtering features -->
-    <!-- Nullish になり得ない所でも型安全性のため Non-null Assertion はしない -->
-    <ListingTable v-if="isLoaded" :cols="cols" :row-ids="submissionIds">
-      <template #head="{ colId }">
-        {{ cols.find(({ id }) => id === colId)?.name }}
+  <PageSwitcher v-if="totalPage > 1" v-model="page" :begin="0" :end="totalPage" class="mb-6" />
+  <!-- TODO: add sorting and filtering features -->
+  <!-- Nullish になり得ない所でも型安全性のため Non-null Assertion はしない -->
+  <ListingTable v-if="isLoaded" :cols="cols" :row-ids="submissionIds">
+    <template #head="{ colId }">
+      {{ cols.find(({ id }) => id === colId)?.name }}
+    </template>
+    <template #cell="{ rowId, colId }">
+      <!-- 文字列のみとは限らずリンクやアイコンなどを含めるようにするため、関数に切り出してはいない -->
+      <template v-if="colId === 'submittedAt'">
+        {{ dateToString(submissions.get(rowId)?.submittedAt) }}
       </template>
-      <template #cell="{ rowId, colId }">
-        <!-- 文字列のみとは限らずリンクやアイコンなどを含めるようにするため、関数に切り出してはいない -->
-        <template v-if="colId === 'submittedAt'">
-          {{ dateToString(submissions.get(rowId)?.submittedAt) }}
-        </template>
-        <template v-else-if="colId === 'userName'">
-          {{ submissions.get(rowId)?.userName }}
-        </template>
-        <template v-else-if="colId === 'totalScore'">
-          {{ submissions.get(rowId)?.totalScore }}
-        </template>
-        <template v-else-if="colId === 'codeLength'">
-          {{ Math.ceil(submissions.get(rowId)?.codeLength ?? -1) }} Byte
-        </template>
-        <template v-else-if="colId === 'judgeStatus'">
-          {{ submissions.get(rowId)?.judgeStatus }}
-        </template>
-        <template v-else-if="colId === 'maxTime'">
-          {{ submissions.get(rowId)?.maxTime }} ms
-        </template>
-        <template v-else-if="colId === 'maxMemory'">
-          {{ submissions.get(rowId)?.maxMemory.toFixed(3) }} MiB
-        </template>
-        <template v-else>Unknown column: {{ colId }}</template>
+      <template v-else-if="colId === 'userName'">
+        {{ submissions.get(rowId)?.userName }}
       </template>
-    </ListingTable>
-    <div v-else>読み込み中...</div>
-  </div>
-  <PageSwitcher v-model="page" :begin="0" :end="totalPage" />
+      <template v-else-if="colId === 'totalScore'">
+        {{ submissions.get(rowId)?.totalScore }}
+      </template>
+      <template v-else-if="colId === 'codeLength'">
+        {{ Math.ceil(submissions.get(rowId)?.codeLength ?? -1) }} Byte
+      </template>
+      <template v-else-if="colId === 'judgeStatus'">
+        {{ submissions.get(rowId)?.judgeStatus }}
+      </template>
+      <template v-else-if="colId === 'maxTime'">
+        {{ submissions.get(rowId)?.maxTime }} ms
+      </template>
+      <template v-else-if="colId === 'maxMemory'">
+        {{ submissions.get(rowId)?.maxMemory.toFixed(3) }} MiB
+      </template>
+      <template v-else>Unknown column: {{ colId }}</template>
+    </template>
+  </ListingTable>
+  <div v-else>読み込み中...</div>
+  <PageSwitcher v-if="totalPage > 1" v-model="page" :begin="0" :end="totalPage" class="mt-6" />
 </template>
 
 <style scoped></style>

--- a/src/components/SubmitForm.vue
+++ b/src/components/SubmitForm.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import CodeBlock from '@/components/CodeBlock.vue'
 import PrimaryButton from '@/components/Controls/PrimaryButton.vue'
 import { type Language, LanguageApi, SubmissionsApi } from '@/api/generated'
-import { onMounted, ref } from 'vue'
-import router from '@/router'
+
+const router = useRouter()
 
 const { problemId } = defineProps<{
   problemId: number

--- a/src/views/ResetPasswordAfterMailView.vue
+++ b/src/views/ResetPasswordAfterMailView.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import router from '@/router'
-import { AuthenticationApi } from '@/api/generated'
+import { useRouter } from 'vue-router'
 import type { Email } from '@/api/generated'
+import { AuthenticationApi } from '@/api/generated'
 
 import BorderedButton from '@/components/Controls/BorderedButton.vue'
 import PrimaryButton from '@/components/Controls/PrimaryButton.vue'
+
+const router = useRouter()
 
 const email: string = history.state.email ?? ''
 const emailAddress: Email = { email: email }
@@ -17,7 +19,7 @@ const requestResetPassword = async () => {
   console.log(email)
   const authApi = new AuthenticationApi()
   await authApi.postRequestResetPassword({ email: emailAddress })
-  router.push({ path: '/reset-password/after-mail', state: { email: email } })
+  await router.push({ path: '/reset-password/after-mail', state: { email: email } })
 }
 </script>
 

--- a/src/views/ResetPasswordView.vue
+++ b/src/views/ResetPasswordView.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import router from '@/router'
-import { AuthenticationApi } from '@/api/generated'
+import { useRouter } from 'vue-router'
 import type { Email } from '@/api/generated'
+import { AuthenticationApi } from '@/api/generated'
 import isEmail from 'validator/lib/isEmail'
 
 import EmailTextbox from '@/components/Controls/Textbox/EmailTextbox.vue'
 import PrimaryButton from '@/components/Controls/PrimaryButton.vue'
+
+const router = useRouter()
 
 const emailAddress = ref<Email>({
   email: ''
@@ -16,7 +18,10 @@ const requestResetPassword = async () => {
   if (!isEmail(emailAddress.value.email)) return
   const authApi = new AuthenticationApi()
   await authApi.postRequestResetPassword({ email: emailAddress.value })
-  router.push({ path: '/reset-password/after-mail', state: { email: emailAddress.value.email } })
+  await router.push({
+    path: '/reset-password/after-mail',
+    state: { email: emailAddress.value.email }
+  })
 }
 </script>
 

--- a/src/views/UserView.vue
+++ b/src/views/UserView.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
 import { useRoute } from 'vue-router'
 import SideMenuUserPage from '@/components/Navigations/SideMenu/SideMenuUserPage.vue'
+import { ref, watch } from 'vue'
 
 const route = useRoute()
 
 if (typeof route.params.id !== 'string') throw new Error('Invalid route')
-const username = route.params.id
+const username = ref<string>('')
+watch(
+  () => route.params.id,
+  (id) => {
+    username.value = `${id}`
+  },
+  { immediate: true }
+)
 // TODO: Fetch user data
 </script>
 

--- a/src/views/user/UserProblems.vue
+++ b/src/views/user/UserProblems.vue
@@ -1,8 +1,17 @@
-<script setup lang="ts"></script>
+<script lang="ts" setup>
+import { useQueryParamInt } from '@/composables/useQueryParam'
+import ProblemsList from '@/components/ProblemsList.vue'
+
+const { username } = defineProps<{ username: string }>()
+const page = useQueryParamInt('page', 0, true)
+</script>
 
 <template>
-  <div>
-    <h2>User Problems</h2>
+  <div class="rounded-lg border border-solid border-border-secondary pt-28 text-center">
+    <h2 class="fontstyle-ui-title-large">問題一覧<br />テーブル</h2>
+    <section class="p-10">
+      <ProblemsList v-model:page="page" :username="username" />
+    </section>
   </div>
 </template>
 


### PR DESCRIPTION
close #66 

## やったこと・相談

- ユーザーページに問題一覧テーブルを追加した
  - そのために、`SubmissionsList` を真似して `ProblemsList` を作った
  - 問題一覧は複数ページにならないことが多いことから 1 ページの時はページネーションのボタンは邪魔なことに気がついたため、両方とも 1 ページの時は `PageSwitcher` を隠すように
- `SideMenuUserPage` で提出一覧、問題一覧ページにアクセスできるようにした
  - そのために、`SideMenuBase` をリンクに対応させた
    - リンクとして扱うボタンは `a` タグにするべきなので、`href` が指定されたときはボタンが `a` タグで囲まれるようにした
      - `a` タグそのまま使うんじゃなくて、`router-link` を使うべき？
        - 今の `<component :is=` を使う実装だとそれが難しそう…？
      - ほんとは `onClick` が指定されていないときは `button` タグじゃなくすべきだろうけど、後回しでやってない。まとめてやっちゃうべき？
    - `router` を使うために他の実装を見たら `useRouter()` を使う実装と `@/router` から取ってきてる実装が混ざっていたので、`useRouter()` を使うよう揃えた
      - `@/router` はコンポーネント以外のための物という認識ですが、あってる…？
  - メニューが現在いるページと連動するようにした
    - 戻るボタンとかで壊れないよう、`watch` で監視している

## 具体的かつ客観的な GitHub Copilot による要約

このプルリクエストでは、アプリケーションのナビゲーション、状態管理、およびユーザーエクスペリエンスを向上させるために、複数のコンポーネントにわたるいくつかの機能強化とリファクタリングを導入しています。

### ナビゲーションの強化:
* [`src/components/Navigations/SideMenu/SideMenuBase.vue`](diffhunk://#diff-c7b429ec03da3b548af02877d3f16b326f8f55f0fced1440579bee4a4ea08d2dR2-R18): ナビゲーション用に `href` サポートを追加し、`SideMenuProps` 型を更新して `href` プロパティをオプションとして含めるようにしました。また、`vue-router` を統合してナビゲーション処理を強化しました。[[1]](diffhunk://#diff-c7b429ec03da3b548af02877d3f16b326f8f55f0fced1440579bee4a4ea08d2dR2-R18) [[2]](diffhunk://#diff-c7b429ec03da3b548af02877d3f16b326f8f55f0fced1440579bee4a4ea08d2dL26-R73)
* [`src/components/Navigations/SideMenu/SideMenuUserPage.vue`](diffhunk://#diff-1129c17c8c1f50348059d38eb19d86df7f10297d68187307b6748bc4ed879d4fR2-R10): `onClick` ハンドラを `href` プロパティに置き換え、ルートパスに基づいて `currentTab` を更新するウォッチャーを追加しました。[[1]](diffhunk://#diff-1129c17c8c1f50348059d38eb19d86df7f10297d68187307b6748bc4ed879d4fR2-R10) [[2]](diffhunk://#diff-1129c17c8c1f50348059d38eb19d86df7f10297d68187307b6748bc4ed879d4fL24-R32) [[3]](diffhunk://#diff-1129c17c8c1f50348059d38eb19d86df7f10297d68187307b6748bc4ed879d4fR47-R64)

### 状態管理:
* [`src/components/ProblemsList.vue`](diffhunk://#diff-93ace4cadd7c846130e0eed46c9dc96ad86accd859abc63a827fed6fc5f196ccR1-R83): API 統合、ページネーション、動的な状態更新を含む問題リストの状態管理を導入しました。
* [`src/views/UserView.vue`](diffhunk://#diff-0c24b34403a270c9d68f22f489ffc1c159c056a634827037c6bb9d13075ab230R4-R16): ルートパラメータに基づいて `username` の `ref` を更新するウォッチャーを追加し、動的なユーザーデータ取得を実現しました。

### フォーム処理:
* `src/views/ResetPasswordAfterMailView.vue`, `src/views/ResetPasswordView.vue`: `vue-router` を使用したナビゲーションにリファクタリングし、非同期ナビゲーションを処理するパスワードリセットロジックを更新しました。[[1]](diffhunk://#diff-a9b7696a9c087e62819151359e5a59876ded8633e40500d5d6e8fcdfa4ef16b4L2-R10) [[2]](diffhunk://#diff-a9b7696a9c087e62819151359e5a59876ded8633e40500d5d6e8fcdfa4ef16b4L20-R22) [[3]](diffhunk://#diff-af08512556ca23aec7787cd4004353f11f334e3f8726e0b1633208b63b5ff4f7L3-R12) [[4]](diffhunk://#diff-af08512556ca23aec7787cd4004353f11f334e3f8726e0b1633208b63b5ff4f7L19-R24)

### ユーザーインターフェースの改善:
* [`src/views/user/UserProblems.vue`](diffhunk://#diff-ec4011cb39b0da30516b246a9fc28b0150e2f297c23024fc1ca3acbf2f7d16e9L1-R14): ユーザーの問題リスト表示を整理し、`ProblemsList` コンポーネントを統合してより見やすいレイアウトにしました。

これらの変更により、アプリケーションのナビゲーション、状態管理、およびユーザーインターフェースが改善され、よりシームレスで効率的なユーザーエクスペリエンスを提供します。
